### PR TITLE
Fix JSON decoding on Python 3.5

### DIFF
--- a/pyinstapaper/instapaper.py
+++ b/pyinstapaper/instapaper.py
@@ -74,7 +74,7 @@ class Instapaper(object):
         log.debug('CONTENT: %s ...', content[:50])
         if returns_json:
             try:
-                data = json.loads(content)
+                data = json.loads(content.decode('utf-8'))
                 if isinstance(data, list) and len(data) == 1:
                     # ugly -- API always returns a list even when you expect
                     # only one item


### PR DESCRIPTION
Using pyinstapaper on Python 3.5, I was getting the following error:

```
Traceback (most recent call last):
# snip...
 File "/.../venv/lib/python3.5/site-packages/pyinstapaper/instapaper.py", line 113, in get_bookmarks
   response = self.request(path, params)
 File "/.../venv/lib/python3.5/site-packages/pyinstapaper/instapaper.py", line 77, in request
   data = json.loads(content)
 File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
   s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

This appears to be because the `content` there is `bytes`, not `str`. [`json.loads` in Python 3.6](https://docs.python.org/3.6/library/json.html#json.loads) or later will decode `bytes` for you, but [`json.loads` in Python 3.5](https://docs.python.org/3.5/library/json.html#json.loads) does not.

This change explicitly decodes the `content`, allowing for compatibility with Python 3.5 and 3.6+.