### PR TITLE
Fix install requires lxml version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'future',
     'httplib2>=0.9',
-    'lxml>=3.4,<=4',
+    'lxml>=3.4,<5',
     'oauth2>=1.9,<2',
     'requests>=2.7,<3',
 ]


### PR DESCRIPTION
[lxml](https://pypi.org/project/lxml/) 4.0.0 does not build on macOS 10.14. The latest version of lxml (4.4.1) does. The `instapaper2pdf.py` example works without modification.

I believe this was just a typo because `lxml==4.2.1` appears in [`requirements.txt`](https://github.com/mdorn/pyinstapaper/blob/master/requirements.txt#L6).

(Thanks for creating this package. 😄)